### PR TITLE
Replace obsolete xUnit helpers in JSONPath tests

### DIFF
--- a/JsonPathLINQ.sln
+++ b/JsonPathLINQ.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.0.11201.2 d18.0
+VisualStudioVersion = 18.0.11201.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JsonPathLINQ", "src\JsonPathLINQ\JsonPathLINQ.csproj", "{E48A6D2C-5609-433A-B1F2-20018F36369A}"
 EndProject
@@ -13,23 +13,79 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\release.yaml = .github\workflows\release.yaml
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClientGo.JsonPath", "src\ClientGo.JsonPath\ClientGo.JsonPath.csproj", "{788D9724-5298-4052-A187-A63EB3CB512A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClientGo.JsonPath.Tests", "tests\ClientGo.JsonPath.Tests\ClientGo.JsonPath.Tests.csproj", "{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E48A6D2C-5609-433A-B1F2-20018F36369A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E48A6D2C-5609-433A-B1F2-20018F36369A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E48A6D2C-5609-433A-B1F2-20018F36369A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E48A6D2C-5609-433A-B1F2-20018F36369A}.Debug|x64.Build.0 = Debug|Any CPU
+		{E48A6D2C-5609-433A-B1F2-20018F36369A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E48A6D2C-5609-433A-B1F2-20018F36369A}.Debug|x86.Build.0 = Debug|Any CPU
 		{E48A6D2C-5609-433A-B1F2-20018F36369A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E48A6D2C-5609-433A-B1F2-20018F36369A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E48A6D2C-5609-433A-B1F2-20018F36369A}.Release|x64.ActiveCfg = Release|Any CPU
+		{E48A6D2C-5609-433A-B1F2-20018F36369A}.Release|x64.Build.0 = Release|Any CPU
+		{E48A6D2C-5609-433A-B1F2-20018F36369A}.Release|x86.ActiveCfg = Release|Any CPU
+		{E48A6D2C-5609-433A-B1F2-20018F36369A}.Release|x86.Build.0 = Release|Any CPU
 		{B4317BB6-F3BA-4176-9389-9BB15406D47E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B4317BB6-F3BA-4176-9389-9BB15406D47E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4317BB6-F3BA-4176-9389-9BB15406D47E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B4317BB6-F3BA-4176-9389-9BB15406D47E}.Debug|x64.Build.0 = Debug|Any CPU
+		{B4317BB6-F3BA-4176-9389-9BB15406D47E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B4317BB6-F3BA-4176-9389-9BB15406D47E}.Debug|x86.Build.0 = Debug|Any CPU
 		{B4317BB6-F3BA-4176-9389-9BB15406D47E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4317BB6-F3BA-4176-9389-9BB15406D47E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4317BB6-F3BA-4176-9389-9BB15406D47E}.Release|x64.ActiveCfg = Release|Any CPU
+		{B4317BB6-F3BA-4176-9389-9BB15406D47E}.Release|x64.Build.0 = Release|Any CPU
+		{B4317BB6-F3BA-4176-9389-9BB15406D47E}.Release|x86.ActiveCfg = Release|Any CPU
+		{B4317BB6-F3BA-4176-9389-9BB15406D47E}.Release|x86.Build.0 = Release|Any CPU
+		{788D9724-5298-4052-A187-A63EB3CB512A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{788D9724-5298-4052-A187-A63EB3CB512A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{788D9724-5298-4052-A187-A63EB3CB512A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{788D9724-5298-4052-A187-A63EB3CB512A}.Debug|x64.Build.0 = Debug|Any CPU
+		{788D9724-5298-4052-A187-A63EB3CB512A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{788D9724-5298-4052-A187-A63EB3CB512A}.Debug|x86.Build.0 = Debug|Any CPU
+		{788D9724-5298-4052-A187-A63EB3CB512A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{788D9724-5298-4052-A187-A63EB3CB512A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{788D9724-5298-4052-A187-A63EB3CB512A}.Release|x64.ActiveCfg = Release|Any CPU
+		{788D9724-5298-4052-A187-A63EB3CB512A}.Release|x64.Build.0 = Release|Any CPU
+		{788D9724-5298-4052-A187-A63EB3CB512A}.Release|x86.ActiveCfg = Release|Any CPU
+		{788D9724-5298-4052-A187-A63EB3CB512A}.Release|x86.Build.0 = Release|Any CPU
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}.Debug|x64.Build.0 = Debug|Any CPU
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}.Debug|x86.Build.0 = Debug|Any CPU
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}.Release|x64.ActiveCfg = Release|Any CPU
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}.Release|x64.Build.0 = Release|Any CPU
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}.Release|x86.ActiveCfg = Release|Any CPU
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{788D9724-5298-4052-A187-A63EB3CB512A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{D78143CD-68FB-450A-BDAF-CF105DDF1FAB} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F8180129-0E80-4703-988A-1CB31BF227C2}

--- a/src/ClientGo.JsonPath/ClientGo.JsonPath.csproj
+++ b/src/ClientGo.JsonPath/ClientGo.JsonPath.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/ClientGo.JsonPath/JsonPath.cs
+++ b/src/ClientGo.JsonPath/JsonPath.cs
@@ -1,0 +1,939 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace ClientGo.JsonPath;
+
+public sealed class JsonPath
+{
+    private readonly string _name;
+    private Parser? _parser;
+    private int _beginRange;
+    private int _inRange;
+    private int _endRange;
+    private INode? _lastEndNode;
+    private bool _allowMissingKeys;
+    private bool _outputJson;
+
+    public JsonPath(string name)
+    {
+        _name = name;
+    }
+
+    public static JsonPath Create(string name) => new(name);
+
+    public JsonPath AllowMissingKeys(bool allow)
+    {
+        _allowMissingKeys = allow;
+        return this;
+    }
+
+    public void EnableJsonOutput(bool enable) => _outputJson = enable;
+
+    public void Parse(string template)
+    {
+        _parser = Parser.Parse(_name, template);
+    }
+
+    public void Execute(TextWriter writer, object? data)
+    {
+        if (writer is null)
+        {
+            throw new ArgumentNullException(nameof(writer));
+        }
+
+        var results = FindResults(data);
+        foreach (var result in results)
+        {
+            PrintResults(writer, result);
+        }
+    }
+
+    public List<List<object?>> FindResults(object? data)
+    {
+        if (_parser is null)
+        {
+            throw new InvalidOperationException($"{_name} is an incomplete jsonpath template");
+        }
+
+        var normalized = Normalize(data);
+        var current = new List<object?> { normalized };
+        var nodes = _parser.Root.Nodes.ToList();
+        var fullResult = new List<List<object?>>();
+
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            var node = nodes[i];
+            var results = Walk(current, node);
+
+            if (_endRange > 0 && _endRange <= _inRange)
+            {
+                _endRange--;
+                _lastEndNode = node;
+                break;
+            }
+
+            if (_beginRange > 0)
+            {
+                _beginRange--;
+                _inRange++;
+
+                if (results.Count > 0)
+                {
+                    foreach (var value in results)
+                    {
+                        var originalNodes = _parser.Root.Nodes.ToList();
+                        try
+                        {
+                            _parser.Root.ReplaceNodes(nodes.Skip(i + 1));
+                            var nested = FindResults(value);
+                            fullResult.AddRange(nested);
+                        }
+                        finally
+                        {
+                            _parser.Root.ReplaceNodes(originalNodes);
+                        }
+                    }
+                }
+                else
+                {
+                    var originalNodes = _parser.Root.Nodes.ToList();
+                    try
+                    {
+                        _parser.Root.ReplaceNodes(nodes.Skip(i + 1));
+                        _ = FindResults(null);
+                    }
+                    finally
+                    {
+                        _parser.Root.ReplaceNodes(originalNodes);
+                    }
+                }
+
+                _inRange--;
+
+                for (var k = i + 1; k < nodes.Count; k++)
+                {
+                    if (ReferenceEquals(nodes[k], _lastEndNode))
+                    {
+                        i = k;
+                        break;
+                    }
+                }
+
+                continue;
+            }
+
+            fullResult.Add(results);
+        }
+
+        return fullResult;
+    }
+
+    public void PrintResults(TextWriter writer, IReadOnlyList<object?> results)
+    {
+        if (_outputJson)
+        {
+            var array = results.Select(Normalize).ToList();
+            var json = JsonSerializer.Serialize(array, SerializerOptionsIndented);
+            writer.Write(json);
+            if (!json.EndsWith("\n", StringComparison.Ordinal))
+            {
+                writer.WriteLine();
+            }
+
+            return;
+        }
+
+        for (var i = 0; i < results.Count; i++)
+        {
+            var value = results[i];
+            var text = EvaluateOutput(value, out _);
+            writer.Write(text);
+
+            if (i != results.Count - 1)
+            {
+                writer.Write(' ');
+            }
+        }
+    }
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private static readonly JsonSerializerOptions SerializerOptionsIndented = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private static string EvaluateOutput(object? value, out bool outputAsJson)
+    {
+        var normalized = Normalize(value);
+        if (normalized is null)
+        {
+            outputAsJson = false;
+            return "null";
+        }
+
+        if (normalized is string s)
+        {
+            outputAsJson = false;
+            return s;
+        }
+
+        if (normalized is bool b)
+        {
+            outputAsJson = false;
+            return b ? "true" : "false";
+        }
+
+        if (normalized is IFormattable formattable && IsNumber(normalized))
+        {
+            outputAsJson = false;
+            return formattable.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty;
+        }
+
+        if (normalized is IEnumerable && normalized is not string)
+        {
+            var json = JsonSerializer.Serialize(normalized, SerializerOptions);
+            outputAsJson = true;
+            return json;
+        }
+
+        var type = normalized.GetType();
+        if (type.IsClass || (type.IsValueType && !IsPrimitive(type)))
+        {
+            var json = JsonSerializer.Serialize(normalized, SerializerOptions);
+            outputAsJson = true;
+            return json;
+        }
+
+        outputAsJson = false;
+        return Convert.ToString(normalized, CultureInfo.InvariantCulture) ?? string.Empty;
+    }
+
+    private List<object?> Walk(List<object?> values, INode node)
+    {
+        return node switch
+        {
+            ListNode listNode => EvalList(values, listNode),
+            TextNode textNode => values.Select(_ => (object?)textNode.Text).ToList(),
+            FieldNode fieldNode => EvalField(values, fieldNode),
+            ArrayNode arrayNode => EvalArray(values, arrayNode),
+            FilterNode filterNode => EvalFilter(values, filterNode),
+            IntNode intNode => values.Select(_ => (object?)intNode.Value).ToList(),
+            FloatNode floatNode => values.Select(_ => (object?)floatNode.Value).ToList(),
+            BoolNode boolNode => values.Select(_ => (object?)boolNode.Value).ToList(),
+            WildcardNode wildcardNode => EvalWildcard(values),
+            RecursiveNode recursiveNode => EvalRecursive(values),
+            UnionNode unionNode => EvalUnion(values, unionNode),
+            IdentifierNode identifierNode => EvalIdentifier(values, identifierNode),
+            _ => throw new InvalidOperationException($"unexpected node {node}")
+        };
+    }
+
+    private List<object?> EvalList(List<object?> values, ListNode node)
+    {
+        var current = values;
+        foreach (var child in node.Nodes)
+        {
+            current = Walk(current, child);
+        }
+
+        return current;
+    }
+
+    private List<object?> EvalIdentifier(List<object?> values, IdentifierNode node)
+    {
+        switch (node.Name)
+        {
+            case "range":
+                _beginRange++;
+                return values;
+            case "end":
+                if (_inRange > 0)
+                {
+                    _endRange++;
+                    return new List<object?>();
+                }
+
+                throw new InvalidOperationException("not in range, nothing to end");
+            default:
+                throw new InvalidOperationException($"unrecognized identifier {node.Name}");
+        }
+    }
+
+    private List<object?> EvalArray(List<object?> input, ArrayNode node)
+    {
+        var result = new List<object?>();
+        foreach (var value in input)
+        {
+            var indirect = Indirect(Normalize(value), out var isNil);
+            if (isNil)
+            {
+                continue;
+            }
+
+            if (!TryGetList(indirect, out var list))
+            {
+                throw new InvalidOperationException($"{GetTypeName(indirect)} is not array or slice");
+            }
+
+            var parameters = node.Params.Select(p => p).ToArray();
+            if (!parameters[0].Known)
+            {
+                parameters[0].Value = 0;
+            }
+
+            if (parameters[0].Value < 0)
+            {
+                parameters[0].Value += list.Count;
+            }
+
+            if (!parameters[1].Known)
+            {
+                parameters[1].Value = list.Count;
+            }
+
+            if (parameters[1].Value < 0 || (parameters[1].Value == 0 && parameters[1].Derived))
+            {
+                parameters[1].Value += list.Count;
+            }
+
+            var sliceLength = list.Count;
+            if (parameters[1].Value != parameters[0].Value)
+            {
+                if (parameters[0].Value >= sliceLength || parameters[0].Value < 0)
+                {
+                    throw new InvalidOperationException($"array index out of bounds: index {parameters[0].Value}, length {sliceLength}");
+                }
+
+                if (parameters[1].Value > sliceLength || parameters[1].Value < 0)
+                {
+                    throw new InvalidOperationException($"array index out of bounds: index {parameters[1].Value - 1}, length {sliceLength}");
+                }
+
+                if (parameters[0].Value > parameters[1].Value)
+                {
+                    throw new InvalidOperationException($"starting index {parameters[0].Value} is greater than ending index {parameters[1].Value}");
+                }
+            }
+            else
+            {
+                continue;
+            }
+
+            var step = 1;
+            if (parameters[2].Known)
+            {
+                if (parameters[2].Value <= 0)
+                {
+                    throw new InvalidOperationException("step must be > 0");
+                }
+
+                step = parameters[2].Value;
+            }
+
+            for (var i = parameters[0].Value; i < parameters[1].Value && i < list.Count; i += step)
+            {
+                result.Add(list[i]);
+            }
+        }
+
+        return result;
+    }
+
+    private List<object?> EvalUnion(List<object?> input, UnionNode node)
+    {
+        var result = new List<object?>();
+        foreach (var listNode in node.Nodes)
+        {
+            var values = EvalList(input, listNode);
+            result.AddRange(values);
+        }
+
+        return result;
+    }
+
+    private List<object?> EvalField(List<object?> input, FieldNode node)
+    {
+        var results = new List<object?>();
+        var hadValues = false;
+        if (input.Count == 0)
+        {
+            return results;
+        }
+
+        foreach (var value in input)
+        {
+            var normalized = Normalize(value);
+            var indirect = Indirect(normalized, out var isNil);
+            if (isNil)
+            {
+                continue;
+            }
+
+            hadValues = true;
+
+            if (TryGetDictionaryValue(indirect, node.Value, out var dictValue))
+            {
+                results.Add(dictValue);
+                continue;
+            }
+
+            if (TryGetMemberValue(indirect, node.Value, out var memberValue))
+            {
+                results.Add(memberValue);
+            }
+        }
+
+        if (results.Count == 0)
+        {
+            if (!hadValues)
+            {
+                return results;
+            }
+
+            if (!_allowMissingKeys)
+            {
+                throw new InvalidOperationException($"{node.Value} is not found");
+            }
+        }
+
+        return results;
+    }
+
+    private List<object?> EvalWildcard(List<object?> input)
+    {
+        var results = new List<object?>();
+        foreach (var value in input)
+        {
+            var normalized = Normalize(value);
+            var indirect = Indirect(normalized, out var isNil);
+            if (isNil)
+            {
+                continue;
+            }
+
+            if (indirect is null)
+            {
+                continue;
+            }
+
+            switch (indirect)
+            {
+                case IDictionary dictionary:
+                    foreach (DictionaryEntry entry in dictionary)
+                    {
+                        results.Add(entry.Value);
+                    }
+
+                    break;
+                case IEnumerable enumerable when indirect is not string:
+                    foreach (var item in enumerable)
+                    {
+                        results.Add(item);
+                    }
+
+                    break;
+                default:
+                    foreach (var member in GetMemberValues(indirect))
+                    {
+                        results.Add(member);
+                    }
+
+                    break;
+            }
+        }
+
+        return results;
+    }
+
+    private List<object?> EvalRecursive(List<object?> input)
+    {
+        var results = new List<object?>();
+        foreach (var value in input)
+        {
+            var normalized = Normalize(value);
+            var indirect = Indirect(normalized, out var isNil);
+            if (isNil)
+            {
+                continue;
+            }
+
+            if (indirect is null)
+            {
+                continue;
+            }
+
+            var children = new List<object?>();
+            switch (indirect)
+            {
+                case IDictionary dictionary:
+                    foreach (DictionaryEntry entry in dictionary)
+                    {
+                        children.Add(entry.Value);
+                    }
+
+                    break;
+                case IEnumerable enumerable when indirect is not string:
+                    foreach (var item in enumerable)
+                    {
+                        children.Add(item);
+                    }
+
+                    break;
+                default:
+                    children.AddRange(GetMemberValues(indirect));
+                    break;
+            }
+
+            if (children.Count > 0)
+            {
+                results.Add(indirect);
+                var deeper = EvalRecursive(children);
+                results.AddRange(deeper);
+            }
+        }
+
+        return results;
+    }
+
+    private List<object?> EvalFilter(List<object?> input, FilterNode node)
+    {
+        var results = new List<object?>();
+        foreach (var value in input)
+        {
+            var indirect = Indirect(Normalize(value), out _);
+            if (!TryGetList(indirect, out var list))
+            {
+                throw new InvalidOperationException($"{GetTypeName(indirect)} is not array or slice and cannot be filtered");
+            }
+
+            for (var i = 0; i < list.Count; i++)
+            {
+                var item = list[i];
+                var temp = new List<object?> { item };
+                List<object?> lefts;
+                try
+                {
+                    lefts = EvalList(temp, node.Left);
+                }
+                catch (InvalidOperationException ex) when (IsMissingKeyException(ex))
+                {
+                    continue;
+                }
+
+                if (node.Operator == "exists")
+                {
+                    if (lefts.Count > 0)
+                    {
+                        results.Add(item);
+                    }
+
+                    continue;
+                }
+
+                if (lefts.Count == 0)
+                {
+                    continue;
+                }
+
+                if (lefts.Count > 1)
+                {
+                    throw new InvalidOperationException("can only compare one element at a time");
+                }
+
+                var left = Normalize(lefts[0]);
+                List<object?> rights;
+                try
+                {
+                    rights = EvalList(temp, node.Right);
+                }
+                catch (InvalidOperationException ex) when (IsMissingKeyException(ex))
+                {
+                    continue;
+                }
+                if (rights.Count == 0)
+                {
+                    continue;
+                }
+
+                if (rights.Count > 1)
+                {
+                    throw new InvalidOperationException("can only compare one element at a time");
+                }
+
+                var right = Normalize(rights[0]);
+                var pass = CompareFilter(left, right, node.Operator);
+                if (pass)
+                {
+                    results.Add(item);
+                }
+            }
+        }
+
+        return results;
+    }
+
+    private static bool CompareFilter(object? left, object? right, string op)
+    {
+        return op switch
+        {
+            "<" => Compare(left, right) < 0,
+            ">" => Compare(left, right) > 0,
+            "==" => EqualsValue(left, right),
+            "!=" => !EqualsValue(left, right),
+            "<=" => Compare(left, right) <= 0,
+            ">=" => Compare(left, right) >= 0,
+            _ => throw new InvalidOperationException($"unrecognized filter operator {op}")
+        };
+    }
+
+    private static bool EqualsValue(object? left, object? right)
+    {
+        left = Normalize(left);
+        right = Normalize(right);
+
+        if (left is null || right is null)
+        {
+            return left is null && right is null;
+        }
+
+        if (IsNumber(left) && IsNumber(right))
+        {
+            return Convert.ToDouble(left, CultureInfo.InvariantCulture).Equals(
+                Convert.ToDouble(right, CultureInfo.InvariantCulture));
+        }
+
+        return left.Equals(right);
+    }
+
+    private static int Compare(object? left, object? right)
+    {
+        left = Normalize(left);
+        right = Normalize(right);
+
+        if (left is null || right is null)
+        {
+            throw new InvalidOperationException("cannot compare nil values");
+        }
+
+        if (IsNumber(left) && IsNumber(right))
+        {
+            var l = Convert.ToDouble(left, CultureInfo.InvariantCulture);
+            var r = Convert.ToDouble(right, CultureInfo.InvariantCulture);
+            return l.CompareTo(r);
+        }
+
+        if (left is string ls && right is string rs)
+        {
+            return string.Compare(ls, rs, StringComparison.Ordinal);
+        }
+
+        if (left is bool lb && right is bool rb)
+        {
+            return lb.CompareTo(rb);
+        }
+
+        if (left is IComparable comparable && right is not null && right.GetType().IsAssignableFrom(left.GetType()))
+        {
+            return comparable.CompareTo(right);
+        }
+
+        throw new InvalidOperationException("values are not comparable");
+    }
+
+    private static bool IsNumber(object? value)
+    {
+        if (value is null)
+        {
+            return false;
+        }
+
+        var type = value.GetType();
+        type = Nullable.GetUnderlyingType(type) ?? type;
+        return type == typeof(byte) || type == typeof(sbyte) || type == typeof(short) || type == typeof(ushort) ||
+               type == typeof(int) || type == typeof(uint) || type == typeof(long) || type == typeof(ulong) ||
+               type == typeof(float) || type == typeof(double) || type == typeof(decimal);
+    }
+
+    private static bool IsPrimitive(Type type)
+    {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+        return type.IsPrimitive || type.IsEnum || type == typeof(decimal) || type == typeof(string);
+    }
+
+    private static bool IsMissingKeyException(Exception ex) =>
+        ex is InvalidOperationException invalid &&
+        invalid.Message.EndsWith("is not found", StringComparison.Ordinal);
+
+    private static object? Normalize(object? value)
+    {
+        switch (value)
+        {
+            case JsonElement element:
+                return NormalizeJsonElement(element);
+            case JsonNode node:
+                return Normalize(JsonSerializer.Deserialize<object?>(node.ToJsonString()));
+            default:
+                return value;
+        }
+    }
+
+    private static object? NormalizeJsonElement(JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Undefined:
+            case JsonValueKind.Null:
+                return null;
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                return element.GetBoolean();
+            case JsonValueKind.Number:
+                if (element.TryGetInt64(out var l))
+                {
+                    return l;
+                }
+
+                return element.GetDouble();
+            case JsonValueKind.String:
+                return element.GetString();
+            case JsonValueKind.Object:
+                var dict = new Dictionary<string, object?>();
+                foreach (var property in element.EnumerateObject())
+                {
+                    dict[property.Name] = NormalizeJsonElement(property.Value);
+                }
+
+                return dict;
+            case JsonValueKind.Array:
+                var list = new List<object?>();
+                foreach (var item in element.EnumerateArray())
+                {
+                    list.Add(NormalizeJsonElement(item));
+                }
+
+                return list;
+            default:
+                return null;
+        }
+    }
+
+    private static object? Indirect(object? value, out bool isNil)
+    {
+        if (value is null)
+        {
+            isNil = true;
+            return null;
+        }
+
+        var type = value.GetType();
+        var underlying = Nullable.GetUnderlyingType(type);
+        if (underlying != null)
+        {
+            var hasValue = (bool)type.GetProperty("HasValue")!.GetValue(value)!;
+            if (!hasValue)
+            {
+                isNil = true;
+                return null;
+            }
+
+            value = type.GetProperty("Value")!.GetValue(value);
+        }
+
+        isNil = value is null;
+        return value;
+    }
+
+    private static bool TryGetList(object? value, out IList<object?> list)
+    {
+        switch (value)
+        {
+            case null:
+                list = Array.Empty<object?>();
+                return false;
+            case IList<object?> typedList:
+                list = typedList;
+                return true;
+            case IList nonGeneric:
+                var temp = new List<object?>();
+                foreach (var item in nonGeneric)
+                {
+                    temp.Add(item);
+                }
+
+                list = temp;
+                return true;
+            case IEnumerable enumerable when value is not string && value is not IDictionary:
+                var results = new List<object?>();
+                foreach (var item in enumerable)
+                {
+                    results.Add(item);
+                }
+
+                list = results;
+                return true;
+            default:
+                list = Array.Empty<object?>();
+                return false;
+        }
+    }
+
+    private static bool TryGetDictionaryValue(object? value, string key, out object? result)
+    {
+        switch (value)
+        {
+            case null:
+                result = null;
+                return false;
+            case IDictionary<string, object?> stringDict:
+                if (stringDict.TryGetValue(key, out var val))
+                {
+                    result = val;
+                    return true;
+                }
+
+                break;
+            case IDictionary dictionary:
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    var convertedKey = ConvertKey(entry.Key, key);
+                    if (convertedKey)
+                    {
+                        result = entry.Value;
+                        return true;
+                    }
+                }
+
+                break;
+        }
+
+        result = null;
+        return false;
+    }
+
+    private static bool ConvertKey(object? candidate, string key)
+    {
+        if (candidate is null)
+        {
+            return false;
+        }
+
+        if (candidate is string s)
+        {
+            return string.Equals(s, key, StringComparison.Ordinal);
+        }
+
+        try
+        {
+            var converted = Convert.ChangeType(key, candidate.GetType(), CultureInfo.InvariantCulture);
+            return candidate.Equals(converted);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryGetMemberValue(object? value, string name, out object? result)
+    {
+        if (value is null)
+        {
+            result = null;
+            return false;
+        }
+
+        var type = value.GetType();
+        var bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase;
+        var property = type.GetProperty(name, bindingFlags);
+        if (property != null)
+        {
+            result = property.GetValue(value);
+            return true;
+        }
+
+        var field = type.GetField(name, bindingFlags);
+        if (field != null)
+        {
+            result = field.GetValue(value);
+            return true;
+        }
+
+        foreach (var prop in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        {
+            var jsonName = prop.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? GetDataMemberName(prop);
+            if (!string.IsNullOrEmpty(jsonName) && string.Equals(jsonName, name, StringComparison.Ordinal))
+            {
+                result = prop.GetValue(value);
+                return true;
+            }
+        }
+
+        foreach (var fld in type.GetFields(BindingFlags.Instance | BindingFlags.Public))
+        {
+            var jsonName = fld.GetCustomAttributes(typeof(JsonPropertyNameAttribute), inherit: true)
+                .Cast<JsonPropertyNameAttribute>()
+                .FirstOrDefault()?.Name;
+            jsonName ??= GetDataMemberName(fld);
+            if (!string.IsNullOrEmpty(jsonName) && string.Equals(jsonName, name, StringComparison.Ordinal))
+            {
+                result = fld.GetValue(value);
+                return true;
+            }
+        }
+
+        result = null;
+        return false;
+    }
+
+    private static string? GetDataMemberName(MemberInfo member)
+    {
+        var dataMemberType = Type.GetType("System.Runtime.Serialization.DataMemberAttribute");
+        if (dataMemberType is null)
+        {
+            return null;
+        }
+
+        var attribute = member.GetCustomAttributes(dataMemberType, inherit: true).FirstOrDefault();
+        if (attribute is null)
+        {
+            return null;
+        }
+
+        var nameProperty = dataMemberType.GetProperty("Name");
+        return nameProperty?.GetValue(attribute) as string;
+    }
+
+    private static IEnumerable<object?> GetMemberValues(object value)
+    {
+        var bindingFlags = BindingFlags.Instance | BindingFlags.Public;
+        foreach (var property in value.GetType().GetProperties(bindingFlags))
+        {
+            if (!property.CanRead || property.GetIndexParameters().Length > 0)
+            {
+                continue;
+            }
+
+            yield return property.GetValue(value);
+        }
+
+        foreach (var field in value.GetType().GetFields(bindingFlags))
+        {
+            yield return field.GetValue(value);
+        }
+    }
+
+    private static string GetTypeName(object? value) => value?.GetType().FullName ?? "null";
+}

--- a/src/ClientGo.JsonPath/Nodes.cs
+++ b/src/ClientGo.JsonPath/Nodes.cs
@@ -1,0 +1,191 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace ClientGo.JsonPath;
+
+internal enum NodeType
+{
+    Text,
+    Array,
+    List,
+    Field,
+    Identifier,
+    Filter,
+    Int,
+    Float,
+    Wildcard,
+    Recursive,
+    Union,
+    Bool,
+}
+
+internal interface INode
+{
+    NodeType Type { get; }
+}
+
+internal sealed class ListNode : INode
+{
+    public NodeType Type => NodeType.List;
+
+    public List<INode> Nodes { get; } = new();
+
+    public void Append(INode node) => Nodes.Add(node);
+
+    public void ReplaceNodes(IEnumerable<INode> nodes)
+    {
+        Nodes.Clear();
+        Nodes.AddRange(nodes);
+    }
+
+    public override string ToString() => Type.ToString();
+}
+
+internal sealed class TextNode : INode
+{
+    public NodeType Type => NodeType.Text;
+
+    public string Text { get; }
+
+    public TextNode(string text) => Text = text;
+
+    public override string ToString() => $"{Type}: {Text}";
+}
+
+internal sealed class FieldNode : INode
+{
+    public NodeType Type => NodeType.Field;
+
+    public string Value { get; }
+
+    public FieldNode(string value) => Value = value;
+
+    public override string ToString() => $"{Type}: {Value}";
+}
+
+internal sealed class IdentifierNode : INode
+{
+    public NodeType Type => NodeType.Identifier;
+
+    public string Name { get; }
+
+    public IdentifierNode(string name) => Name = name;
+
+    public override string ToString() => $"{Type}: {Name}";
+}
+
+internal sealed class FilterNode : INode
+{
+    public NodeType Type => NodeType.Filter;
+
+    public ListNode Left { get; }
+
+    public ListNode Right { get; }
+
+    public string Operator { get; }
+
+    public FilterNode(ListNode left, ListNode right, string @operator)
+    {
+        Left = left;
+        Right = right;
+        Operator = @operator;
+    }
+
+    public override string ToString() => $"{Type}: {Left} {Operator} {Right}";
+}
+
+internal sealed class IntNode : INode
+{
+    public NodeType Type => NodeType.Int;
+
+    public int Value { get; }
+
+    public IntNode(int value) => Value = value;
+
+    public override string ToString() => $"{Type}: {Value}";
+}
+
+internal sealed class FloatNode : INode
+{
+    public NodeType Type => NodeType.Float;
+
+    public double Value { get; }
+
+    public FloatNode(double value) => Value = value;
+
+    public override string ToString() => $"{Type}: {Value.ToString(CultureInfo.InvariantCulture)}";
+}
+
+internal sealed class BoolNode : INode
+{
+    public NodeType Type => NodeType.Bool;
+
+    public bool Value { get; }
+
+    public BoolNode(bool value) => Value = value;
+
+    public override string ToString() => $"{Type}: {Value}";
+}
+
+internal sealed class WildcardNode : INode
+{
+    public NodeType Type => NodeType.Wildcard;
+
+    public override string ToString() => Type.ToString();
+}
+
+internal sealed class RecursiveNode : INode
+{
+    public NodeType Type => NodeType.Recursive;
+
+    public override string ToString() => Type.ToString();
+}
+
+internal sealed class UnionNode : INode
+{
+    public NodeType Type => NodeType.Union;
+
+    public List<ListNode> Nodes { get; }
+
+    public UnionNode(IEnumerable<ListNode> nodes)
+    {
+        Nodes = nodes.ToList();
+    }
+
+    public override string ToString() => Type.ToString();
+}
+
+internal sealed class ArrayNode : INode
+{
+    public NodeType Type => NodeType.Array;
+
+    public ParamsEntry[] Params { get; }
+
+    public ArrayNode(ParamsEntry[] @params)
+    {
+        Params = @params.ToArray();
+    }
+
+    public override string ToString() => $"{Type}: {string.Join(",", Params.Select(p => p.ToString()))}";
+}
+
+internal struct ParamsEntry
+{
+    public bool Known { get; set; }
+
+    public int Value { get; set; }
+
+    public bool Derived { get; set; }
+
+    public ParamsEntry(bool known, int value, bool derived)
+    {
+        Known = known;
+        Value = value;
+        Derived = derived;
+    }
+
+    public override readonly string ToString() =>
+        $"{(Known ? Value.ToString(CultureInfo.InvariantCulture) : "?")}" +
+        (Derived ? " (derived)" : string.Empty);
+}

--- a/src/ClientGo.JsonPath/Parser.cs
+++ b/src/ClientGo.JsonPath/Parser.cs
@@ -1,0 +1,625 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ClientGo.JsonPath;
+
+internal sealed class Parser
+{
+    private const char Eof = '\uffff';
+    private const string LeftDelim = "{";
+    private const string RightDelim = "}";
+
+    private string _input = string.Empty;
+    private int _pos;
+    private int _start;
+    private int _width;
+
+    private static readonly Regex DictKeyRegex = new("^'([^']*)'$", RegexOptions.Compiled);
+    private static readonly Regex SliceOperatorRegex = new("^(-?[\\d]*)(:-?[\\d]*)?(:-?[\\d]*)?$", RegexOptions.Compiled);
+    private static readonly Regex FilterRegex = new("^([^!<>=]+)([!<>=]+)(.+?)$", RegexOptions.Compiled);
+
+    private Parser(string name)
+    {
+        Root = new ListNode();
+    }
+
+    public ListNode Root { get; private set; }
+
+    public static Parser Parse(string name, string text)
+    {
+        var parser = new Parser(name);
+        parser.ParseInternal(text);
+        return parser;
+    }
+
+    private static Parser ParseAction(string name, string text)
+    {
+        var parser = Parse(name, $"{LeftDelim}{text}{RightDelim}");
+        parser.Root = parser.Root.Nodes[0] as ListNode ?? throw new JsonPathParseException("expected list node");
+        return parser;
+    }
+
+    private void ParseInternal(string text)
+    {
+        _input = text;
+        Root = new ListNode();
+        _pos = 0;
+        _start = 0;
+        parseText(Root);
+    }
+
+    private string ConsumeText()
+    {
+        var value = _input[_start.._pos];
+        _start = _pos;
+        return value;
+    }
+
+    private char NextChar()
+    {
+        if (_pos >= _input.Length)
+        {
+            _width = 0;
+            return Eof;
+        }
+
+        var ch = _input[_pos];
+        _width = 1;
+        _pos += _width;
+        return ch;
+    }
+
+    private char PeekChar()
+    {
+        var ch = NextChar();
+        Backup();
+        return ch;
+    }
+
+    private void Backup()
+    {
+        _pos -= _width;
+        if (_pos < _start)
+        {
+            _pos = _start;
+        }
+    }
+
+    private void parseText(ListNode current)
+    {
+        while (true)
+        {
+            if (HasPrefix(LeftDelim))
+            {
+                if (_pos > _start)
+                {
+                    current.Append(new TextNode(ConsumeText()));
+                }
+
+                parseLeftDelim(current);
+                return;
+            }
+
+            if (NextChar() == Eof)
+            {
+                break;
+            }
+        }
+
+        if (_pos > _start)
+        {
+            current.Append(new TextNode(ConsumeText()));
+        }
+    }
+
+    private void parseLeftDelim(ListNode current)
+    {
+        _pos += LeftDelim.Length;
+        ConsumeText();
+        var newNode = new ListNode();
+        current.Append(newNode);
+        parseInsideAction(newNode);
+    }
+
+    private void parseInsideAction(ListNode current)
+    {
+        while (true)
+        {
+            if (HasPrefix(RightDelim))
+            {
+                parseRightDelim(current);
+                return;
+            }
+
+            if (HasPrefix("[?("))
+            {
+                parseFilter(current);
+                return;
+            }
+
+            if (HasPrefix(".."))
+            {
+                parseRecursive(current);
+                return;
+            }
+
+            var r = NextChar();
+            switch (r)
+            {
+                case Eof:
+                case '\n':
+                case '\r':
+                    throw new JsonPathParseException("unclosed action");
+                case ' ':
+                case '\t':
+                    ConsumeText();
+                    continue;
+                case '@':
+                case '$':
+                    ConsumeText();
+                    continue;
+                case '[':
+                    parseArray(current);
+                    return;
+                case '"':
+                case '\'':
+                    parseQuote(current, r);
+                    return;
+                case '.':
+                    parseField(current);
+                    return;
+                case '+':
+                case '-':
+                    Backup();
+                    parseNumber(current);
+                    return;
+                default:
+                    if (char.IsDigit(r))
+                    {
+                        Backup();
+                        parseNumber(current);
+                        return;
+                    }
+
+                    if (IsAlphaNumeric(r))
+                    {
+                        Backup();
+                        parseIdentifier(current);
+                        return;
+                    }
+
+                    throw new JsonPathParseException($"unrecognized character in action: {r}");
+            }
+        }
+    }
+
+    private void parseRightDelim(ListNode current)
+    {
+        _pos += RightDelim.Length;
+        ConsumeText();
+        parseText(Root);
+    }
+
+    private void parseIdentifier(ListNode current)
+    {
+        while (true)
+        {
+            var r = NextChar();
+            if (IsTerminator(r))
+            {
+                Backup();
+                break;
+            }
+        }
+
+        var value = ConsumeText();
+        if (IsBool(value))
+        {
+            if (!bool.TryParse(value, out var parsed))
+            {
+                throw new JsonPathParseException($"cannot parse bool '{value}'");
+            }
+
+            current.Append(new BoolNode(parsed));
+        }
+        else
+        {
+            current.Append(new IdentifierNode(value));
+        }
+
+        parseInsideAction(current);
+    }
+
+    private void parseRecursive(ListNode current)
+    {
+        if (current.Nodes.LastOrDefault()?.Type == NodeType.Recursive)
+        {
+            throw new JsonPathParseException("invalid multiple recursive descent");
+        }
+
+        _pos += "..".Length;
+        ConsumeText();
+        current.Append(new RecursiveNode());
+        if (IsAlphaNumeric(PeekChar()))
+        {
+            parseField(current);
+            return;
+        }
+
+        parseInsideAction(current);
+    }
+
+    private void parseNumber(ListNode current)
+    {
+        var r = PeekChar();
+        if (r == '+' || r == '-')
+        {
+            NextChar();
+        }
+
+        while (true)
+        {
+            r = NextChar();
+            if (r != '.' && !char.IsDigit(r))
+            {
+                Backup();
+                break;
+            }
+        }
+
+        var value = ConsumeText();
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i))
+        {
+            current.Append(new IntNode(i));
+            parseInsideAction(current);
+            return;
+        }
+
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var d))
+        {
+            current.Append(new FloatNode(d));
+            parseInsideAction(current);
+            return;
+        }
+
+        throw new JsonPathParseException($"cannot parse number {value}");
+    }
+
+    private void parseArray(ListNode current)
+    {
+        while (true)
+        {
+            var r = NextChar();
+            if (r == Eof || r == '\n' || r == '\r')
+            {
+                throw new JsonPathParseException("unterminated array");
+            }
+
+            if (r == ']')
+            {
+                break;
+            }
+        }
+
+        var text = ConsumeText();
+        text = text[1..^1];
+        if (text == "*")
+        {
+            text = ":";
+        }
+
+        var parts = text.Split(',');
+        if (parts.Length > 1)
+        {
+            var unionNodes = new List<ListNode>();
+            foreach (var part in parts)
+            {
+                var parser = ParseAction("union", $"[{part.Trim()}]");
+                unionNodes.Add(parser.Root);
+            }
+
+            current.Append(new UnionNode(unionNodes));
+            parseInsideAction(current);
+            return;
+        }
+
+        var dictMatch = DictKeyRegex.Match(text);
+        if (dictMatch.Success)
+        {
+            var parser = ParseAction("arraydict", $".{dictMatch.Groups[1].Value}");
+            foreach (var node in parser.Root.Nodes)
+            {
+                current.Append(node);
+            }
+
+            parseInsideAction(current);
+            return;
+        }
+
+        var sliceMatch = SliceOperatorRegex.Match(text);
+        if (!sliceMatch.Success)
+        {
+            throw new JsonPathParseException($"invalid array index {text}");
+        }
+
+        var parameters = new ParamsEntry[3];
+        for (var i = 0; i < 3; i++)
+        {
+            var value = sliceMatch.Groups[i + 1].Value;
+            if (!string.IsNullOrEmpty(value))
+            {
+                if (i > 0)
+                {
+                    value = value[1..];
+                }
+
+                if (i > 0 && string.IsNullOrEmpty(value))
+                {
+                    parameters[i] = new ParamsEntry(false, 0, false);
+                }
+                else
+                {
+                    if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+                    {
+                        throw new JsonPathParseException($"array index {value} is not a number");
+                    }
+
+                    parameters[i] = new ParamsEntry(true, parsed, false);
+                }
+            }
+            else
+            {
+                if (i == 1)
+                {
+                    parameters[i] = new ParamsEntry(true, parameters[0].Value + 1, true);
+                }
+                else
+                {
+                    parameters[i] = new ParamsEntry(false, 0, false);
+                }
+            }
+        }
+
+        current.Append(new ArrayNode(parameters));
+        parseInsideAction(current);
+    }
+
+    private void parseFilter(ListNode current)
+    {
+        _pos += "[?(".Length;
+        ConsumeText();
+        var begin = false;
+        var end = false;
+        char pair = default;
+
+        while (true)
+        {
+            var r = NextChar();
+            switch (r)
+            {
+                case Eof:
+                case '\n':
+                case '\r':
+                    throw new JsonPathParseException("unterminated filter");
+                case '"':
+                case '\'':
+                    if (!begin)
+                    {
+                        begin = true;
+                        pair = r;
+                        continue;
+                    }
+
+                    if (_input[_pos - 2] != '\\' && r == pair)
+                    {
+                        end = true;
+                    }
+
+                    break;
+                case ')':
+                    if (begin == end)
+                    {
+                        goto FilterDone;
+                    }
+
+                    break;
+            }
+        }
+
+    FilterDone:
+        if (NextChar() != ']')
+        {
+            throw new JsonPathParseException("unclosed array expect ]");
+        }
+
+        var text = ConsumeText();
+        text = text[..^2];
+        var match = FilterRegex.Match(text);
+        if (!match.Success)
+        {
+            var parser = ParseAction("text", text);
+            current.Append(new FilterNode(parser.Root, new ListNode(), "exists"));
+        }
+        else
+        {
+            var leftParser = ParseAction("left", match.Groups[1].Value);
+            var rightParser = ParseAction("right", match.Groups[3].Value);
+            current.Append(new FilterNode(leftParser.Root, rightParser.Root, match.Groups[2].Value));
+        }
+
+        parseInsideAction(current);
+    }
+
+    private void parseQuote(ListNode current, char end)
+    {
+        while (true)
+        {
+            var r = NextChar();
+            if (r == Eof || r == '\n' || r == '\r')
+            {
+                throw new JsonPathParseException("unterminated quoted string");
+            }
+
+            if (r == end && _input[_pos - 2] != '\\')
+            {
+                break;
+            }
+        }
+
+        var value = ConsumeText();
+        var unquoted = UnquoteExtend(value);
+        current.Append(new TextNode(unquoted));
+        parseInsideAction(current);
+    }
+
+    private void parseField(ListNode current)
+    {
+        ConsumeText();
+        while (Advance())
+        {
+        }
+
+        var value = ConsumeText();
+        if (value == "*")
+        {
+            current.Append(new WildcardNode());
+        }
+        else
+        {
+            current.Append(new FieldNode(value.Replace("\\", string.Empty)));
+        }
+
+        parseInsideAction(current);
+    }
+
+    private bool Advance()
+    {
+        var r = NextChar();
+        if (r == '\\')
+        {
+            NextChar();
+        }
+        else if (IsTerminator(r))
+        {
+            Backup();
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool HasPrefix(string prefix) =>
+        _pos + prefix.Length <= _input.Length &&
+        _input.AsSpan(_pos, prefix.Length).SequenceEqual(prefix);
+
+    private static bool IsTerminator(char r) =>
+        r == Eof || r == '.' || r == ',' || r == '[' || r == ']' || r == '$' || r == '@' || r == '{' || r == '}' || r == ' ' ||
+        r == '\t' || r == '\r' || r == '\n';
+
+    private static bool IsAlphaNumeric(char r) => r == '_' || char.IsLetterOrDigit(r);
+
+    private static bool IsBool(string value) => value == "true" || value == "false";
+
+    internal static string UnquoteExtend(string value)
+    {
+        if (value.Length < 2)
+        {
+            throw new JsonPathParseException("invalid syntax");
+        }
+
+        var quote = value[0];
+        if (quote != value[^1])
+        {
+            throw new JsonPathParseException("invalid syntax");
+        }
+
+        var inner = value[1..^1];
+        if (quote != '"' && quote != '\'')
+        {
+            throw new JsonPathParseException("invalid syntax");
+        }
+
+        var builder = new StringBuilder(inner.Length);
+        for (int i = 0; i < inner.Length; i++)
+        {
+            var ch = inner[i];
+            if (ch == '\\')
+            {
+                if (i == inner.Length - 1)
+                {
+                    throw new JsonPathParseException($"invalid escape sequence in {value}");
+                }
+
+                var next = inner[++i];
+                switch (next)
+                {
+                    case '\\':
+                        builder.Append('\\');
+                        break;
+                    case '\'':
+                        builder.Append('\'');
+                        break;
+                    case '"':
+                        builder.Append('"');
+                        break;
+                    case 'b':
+                        builder.Append('\b');
+                        break;
+                    case 'f':
+                        builder.Append('\f');
+                        break;
+                    case 'n':
+                        builder.Append('\n');
+                        break;
+                    case 'r':
+                        builder.Append('\r');
+                        break;
+                    case 't':
+                        builder.Append('\t');
+                        break;
+                    case 'u':
+                        if (i + 4 >= inner.Length)
+                        {
+                            throw new JsonPathParseException($"invalid unicode escape in {value}");
+                        }
+
+                        var hex = inner.Substring(i + 1, 4);
+                        if (!int.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var code))
+                        {
+                            throw new JsonPathParseException($"invalid unicode escape in {value}");
+                        }
+
+                        builder.Append(char.ConvertFromUtf32(code));
+                        i += 4;
+                        break;
+                    default:
+                        builder.Append(next);
+                        break;
+                }
+            }
+            else
+            {
+                builder.Append(ch);
+            }
+        }
+
+        return builder.ToString();
+    }
+}
+
+internal sealed class JsonPathParseException : Exception
+{
+    public JsonPathParseException(string message)
+        : base(message)
+    {
+    }
+
+    public JsonPathParseException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/tests/ClientGo.JsonPath.Tests/ClientGo.JsonPath.Tests.csproj
+++ b/tests/ClientGo.JsonPath.Tests/ClientGo.JsonPath.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ClientGo.JsonPath\ClientGo.JsonPath.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="TestData\**\*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ClientGo.JsonPath.Tests/JsonPathTests.cs
+++ b/tests/ClientGo.JsonPath.Tests/JsonPathTests.cs
@@ -1,0 +1,371 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ClientGo.JsonPath;
+
+namespace ClientGo.JsonPath.Tests;
+
+public record JsonPathTestCase(string Name, string Template, object? Input, string Expected, bool ExpectError = false);
+
+public sealed class JsonPathTests
+{
+    [Theory]
+    [MemberData(nameof(TypesInputData))]
+    public void TypesInput(JsonPathTestCase testCase) => RunTest(testCase);
+
+    [Theory]
+    [MemberData(nameof(StructInputData))]
+    public void StructInput(JsonPathTestCase testCase) => RunTest(testCase);
+
+    [Theory]
+    [MemberData(nameof(StructInputAllowMissingData))]
+    public void StructInputAllowsMissingKeys(JsonPathTestCase testCase) => RunTest(testCase, allowMissingKeys: true);
+
+    [Theory]
+    [MemberData(nameof(StructInputFailureData))]
+    public void StructInputFailures(JsonPathTestCase testCase) => RunTestExpectFailure(testCase);
+
+    [Theory]
+    [MemberData(nameof(JsonInputData))]
+    public void JsonInput(JsonPathTestCase testCase) => RunTest(testCase);
+
+    [Theory]
+    [MemberData(nameof(KubernetesSampleData))]
+    public void KubernetesSamples(JsonPathTestCase testCase) => RunTest(testCase);
+
+    [Theory]
+    [MemberData(nameof(KubernetesSampleSortedData))]
+    public void KubernetesSamplesWithSortedOutput(JsonPathTestCase testCase) => RunTestSorted(testCase);
+
+    [Theory]
+    [MemberData(nameof(EmptyRangeData))]
+    public void EmptyRangeIsValid(JsonPathTestCase testCase) => RunTest(testCase);
+
+    [Fact]
+    public void JsonOutputCanBeEnabled()
+    {
+        var store = new Store
+        {
+            Name = "jsonpath",
+            Book = new List<Book> { new("reference", "Nigel Rees", "Sayings", 8.95f) }
+        };
+
+        var jsonPath = new JsonPath("json-output");
+        jsonPath.Parse("{.Book}");
+        jsonPath.EnableJsonOutput(true);
+        var writer = new StringWriter();
+        jsonPath.Execute(writer, store);
+        var output = writer.ToString();
+        Assert.Equal("[\n  [\n    {\n      \"Category\": \"reference\",\n      \"Author\": \"Nigel Rees\",\n      \"Title\": \"Sayings\",\n      \"Price\": 8.95\n    }\n  ]\n]\n", output);
+    }
+
+    public static TheoryData<JsonPathTestCase> TypesInputData => CreateTypesInputData();
+
+    public static TheoryData<JsonPathTestCase> StructInputData => CreateStructInputData();
+
+    public static TheoryData<JsonPathTestCase> StructInputAllowMissingData => CreateStructInputAllowMissingData();
+
+    public static TheoryData<JsonPathTestCase> StructInputFailureData => CreateStructInputFailureData();
+
+    public static TheoryData<JsonPathTestCase> JsonInputData => CreateJsonInputData();
+
+    public static TheoryData<JsonPathTestCase> KubernetesSampleData => CreateKubernetesSampleData();
+
+    public static TheoryData<JsonPathTestCase> KubernetesSampleSortedData => CreateKubernetesSampleSortedData();
+
+    public static TheoryData<JsonPathTestCase> EmptyRangeData => CreateEmptyRangeData();
+
+    private static void RunTest(JsonPathTestCase testCase, bool allowMissingKeys = false)
+    {
+        var jsonPath = new JsonPath(testCase.Name).AllowMissingKeys(allowMissingKeys);
+        jsonPath.Parse(testCase.Template);
+
+        var writer = new StringWriter();
+        jsonPath.Execute(writer, testCase.Input);
+        Assert.Equal(testCase.Expected, writer.ToString());
+    }
+
+    private static void RunTestSorted(JsonPathTestCase testCase)
+    {
+        var jsonPath = new JsonPath(testCase.Name);
+        jsonPath.Parse(testCase.Template);
+        var writer = new StringWriter();
+        jsonPath.Execute(writer, testCase.Input);
+        var output = writer.ToString();
+        var sortedOutput = output.Split(' ', StringSplitOptions.RemoveEmptyEntries).OrderBy(x => x).ToArray();
+        var sortedExpected = testCase.Expected.Split(' ', StringSplitOptions.RemoveEmptyEntries).OrderBy(x => x).ToArray();
+        Assert.Equal(sortedExpected, sortedOutput);
+    }
+
+    private static void RunTestExpectFailure(JsonPathTestCase testCase)
+    {
+        var jsonPath = new JsonPath(testCase.Name);
+        if (testCase.Template is not null)
+        {
+            try
+            {
+                jsonPath.Parse(testCase.Template);
+            }
+            catch (Exception ex)
+            {
+                Assert.Contains(testCase.Expected, ex.Message);
+                return;
+            }
+        }
+
+        var writer = new StringWriter();
+        var exception = Assert.ThrowsAny<Exception>(() => jsonPath.Execute(writer, testCase.Input));
+        Assert.Contains(testCase.Expected, exception.Message);
+    }
+
+    private static TheoryData<JsonPathTestCase> CreateTypesInputData()
+    {
+        var types = new Dictionary<string, object?>
+        {
+            ["bools"] = new List<bool> { true, false, true, false },
+            ["integers"] = new List<int> { 1, 2, 3, 4 },
+            ["floats"] = new List<double> { 1.0, 2.2, 3.3, 4.0 },
+            ["strings"] = new List<string> { "one", "two", "three", "four" },
+            ["interfaces"] = new List<object?> { true, "one", 1, 1.1 },
+            ["maps"] = new List<Dictionary<string, object?>>
+            {
+                new() { ["name"] = "one", ["value"] = 1 },
+                new() { ["name"] = "two", ["value"] = 2.02 },
+                new() { ["name"] = "three", ["value"] = 3.03 },
+                new() { ["name"] = "four", ["value"] = 4.04 },
+            },
+            ["structs"] = new List<TestStruct>
+            {
+                new("one", 1, "integer"),
+                new("two", 2.002, "float"),
+                new("three", 3, "integer"),
+                new("four", 4.004, "float"),
+            },
+        };
+
+        var data = new TheoryData<JsonPathTestCase>();
+        data.Add(new JsonPathTestCase("boolSlice", "{ .bools }", types, "[true,false,true,false]"));
+        data.Add(new JsonPathTestCase("boolSliceIndex", "{ .bools[0] }", types, "true"));
+        data.Add(new JsonPathTestCase("boolSliceIndexNegative", "{ .bools[-1] }", types, "false"));
+        data.Add(new JsonPathTestCase("boolSubSlice", "{ .bools[0:2] }", types, "true false"));
+        data.Add(new JsonPathTestCase("boolSubSliceFirst", "{ .bools[:2] }", types, "true false"));
+        data.Add(new JsonPathTestCase("boolSubSliceStep", "{ .bools[:4:2] }", types, "true true"));
+        data.Add(new JsonPathTestCase("integerSlice", "{ .integers }", types, "[1,2,3,4]"));
+        data.Add(new JsonPathTestCase("integerSliceIndex", "{ .integers[0] }", types, "1"));
+        data.Add(new JsonPathTestCase("integerSliceNegative", "{ .integers[-2] }", types, "3"));
+        data.Add(new JsonPathTestCase("integerSubSlice", "{ .integers[:2] }", types, "1 2"));
+        data.Add(new JsonPathTestCase("integerSubSliceStep", "{ .integers[:4:2] }", types, "1 3"));
+        data.Add(new JsonPathTestCase("floatSlice", "{ .floats }", types, "[1,2.2,3.3,4]"));
+        data.Add(new JsonPathTestCase("floatSliceIndex", "{ .floats[0] }", types, "1"));
+        data.Add(new JsonPathTestCase("floatSliceNegative", "{ .floats[-2] }", types, "3.3"));
+        data.Add(new JsonPathTestCase("floatSubSlice", "{ .floats[:2] }", types, "1 2.2"));
+        data.Add(new JsonPathTestCase("floatSubSliceStep", "{ .floats[:4:2] }", types, "1 3.3"));
+        data.Add(new JsonPathTestCase("stringSlice", "{ .strings }", types, "[\"one\",\"two\",\"three\",\"four\"]"));
+        data.Add(new JsonPathTestCase("stringSliceIndex", "{ .strings[0] }", types, "one"));
+        data.Add(new JsonPathTestCase("stringSliceNegative", "{ .strings[-2] }", types, "three"));
+        data.Add(new JsonPathTestCase("stringSubSlice", "{ .strings[:2] }", types, "one two"));
+        data.Add(new JsonPathTestCase("stringSubSliceStep", "{ .strings[:4:2] }", types, "one three"));
+        data.Add(new JsonPathTestCase("interfaceSlice", "{ .interfaces }", types, "[true,\"one\",1,1.1]"));
+        data.Add(new JsonPathTestCase("interfaceSliceIndex", "{ .interfaces[0] }", types, "true"));
+        data.Add(new JsonPathTestCase("interfaceSliceNegative", "{ .interfaces[-2] }", types, "1"));
+        data.Add(new JsonPathTestCase("interfaceSubSlice", "{ .interfaces[:2] }", types, "true one"));
+        data.Add(new JsonPathTestCase("interfaceSubSliceStep", "{ .interfaces[:4:2] }", types, "true 1"));
+        data.Add(new JsonPathTestCase("mapSlice", "{ .maps }", types,
+            "[{\"name\":\"one\",\"value\":1},{\"name\":\"two\",\"value\":2.02},{\"name\":\"three\",\"value\":3.03},{\"name\":\"four\",\"value\":4.04}]"));
+        data.Add(new JsonPathTestCase("mapSliceIndex", "{ .maps[0] }", types, "{\"name\":\"one\",\"value\":1}"));
+        data.Add(new JsonPathTestCase("mapSliceNegative", "{ .maps[-2] }", types, "{\"name\":\"three\",\"value\":3.03}"));
+        data.Add(new JsonPathTestCase("mapSubSlice", "{ .maps[:2] }", types, "{\"name\":\"one\",\"value\":1} {\"name\":\"two\",\"value\":2.02}"));
+        data.Add(new JsonPathTestCase("mapSubSliceStep", "{ .maps[::2] }", types, "{\"name\":\"one\",\"value\":1} {\"name\":\"three\",\"value\":3.03}"));
+        data.Add(new JsonPathTestCase("structSlice", "{ .structs }", types,
+            "[{\"name\":\"one\",\"value\":1,\"type\":\"integer\"},{\"name\":\"two\",\"value\":2.002,\"type\":\"float\"},{\"name\":\"three\",\"value\":3,\"type\":\"integer\"},{\"name\":\"four\",\"value\":4.004,\"type\":\"float\"}]"));
+        data.Add(new JsonPathTestCase("structSliceIndex", "{ .structs[0] }", types, "{\"name\":\"one\",\"value\":1,\"type\":\"integer\"}"));
+        data.Add(new JsonPathTestCase("structSliceNegative", "{ .structs[-2] }", types, "{\"name\":\"three\",\"value\":3,\"type\":\"integer\"}"));
+        data.Add(new JsonPathTestCase("structSubSlice", "{ .structs[:2] }", types,
+            "{\"name\":\"one\",\"value\":1,\"type\":\"integer\"} {\"name\":\"two\",\"value\":2.002,\"type\":\"float\"}"));
+        data.Add(new JsonPathTestCase("structSubSliceStep", "{ .structs[::2] }", types,
+            "{\"name\":\"one\",\"value\":1,\"type\":\"integer\"} {\"name\":\"three\",\"value\":3,\"type\":\"integer\"}"));
+
+        return data;
+    }
+
+    private static TheoryData<JsonPathTestCase> CreateStructInputData()
+    {
+        var store = CreateStore();
+
+        var data = new TheoryData<JsonPathTestCase>();
+        data.Add(new JsonPathTestCase("plain", "hello jsonpath", null, "hello jsonpath"));
+        data.Add(new JsonPathTestCase("recursive", "{..}", new[] { 1, 2, 3 }, "[1,2,3]"));
+        data.Add(new JsonPathTestCase("filter", "{[?(@<5)]}", new[] { 2, 6, 3, 7 }, "2 3"));
+        data.Add(new JsonPathTestCase("quote", "{\"{\"}", null, "{"));
+        data.Add(new JsonPathTestCase("union", "{[1,3,4]}", new[] { 0, 1, 2, 3, 4 }, "1 3 4"));
+        data.Add(new JsonPathTestCase("array", "{[0:2]}", new[] { "Monday", "Tuesday" }, "Monday Tuesday"));
+        data.Add(new JsonPathTestCase("variable", "hello {.Name}", store, "hello jsonpath"));
+        data.Add(new JsonPathTestCase("dict slash", "{$.Labels.web/html}", store, "15"));
+        data.Add(new JsonPathTestCase("dict index", "{$.Employees.jason}", store, "manager"));
+        data.Add(new JsonPathTestCase("dict index 2", "{$.Employees.dan}", store, "clerk"));
+        data.Add(new JsonPathTestCase("dict dash", "{.Labels.k8s-app}", store, "20"));
+        data.Add(new JsonPathTestCase("nested", "{.Bicycle[*].Color}", store, "red green"));
+        data.Add(new JsonPathTestCase("all authors", "{.Book[*].Author}", store, "Nigel Rees Evelyn Waugh Herman Melville"));
+        data.Add(new JsonPathTestCase("all fields", "{range .Bicycle[*]}{ \"{\" }{ @.* }{ \"} \" }{end}", store, "{red 19.95 true} {green 20.01 false} "));
+        data.Add(new JsonPathTestCase("recursive price", "{..Price}", store, "8.95 12.99 8.99 19.95 20.01"));
+        data.Add(new JsonPathTestCase("recursive dot price", "{...Price}", store, "8.95 12.99 8.99 19.95 20.01"));
+        data.Add(new JsonPathTestCase("all bicycles", "{.Bicycle}", store,
+            "[{\"Color\":\"red\",\"Price\":19.95,\"IsNew\":true},{\"Color\":\"green\",\"Price\":20.01,\"IsNew\":false}]"));
+        data.Add(new JsonPathTestCase("all struct", "{range .Bicycle[*]}{ @ }{ \" \" }{end}", store,
+            "{\"Color\":\"red\",\"Price\":19.95,\"IsNew\":true} {\"Color\":\"green\",\"Price\":20.01,\"IsNew\":false} "));
+        data.Add(new JsonPathTestCase("last array", "{.Book[-1:]}", store,
+            "{\"Category\":\"fiction\",\"Author\":\"Herman Melville\",\"Title\":\"Moby Dick\",\"Price\":8.99}"));
+        data.Add(new JsonPathTestCase("recursive array", "{..Book[2]}", store,
+            "{\"Category\":\"fiction\",\"Author\":\"Herman Melville\",\"Title\":\"Moby Dick\",\"Price\":8.99}"));
+        data.Add(new JsonPathTestCase("bool filter", "{.Bicycle[?(@.IsNew==true)]}", store,
+            "{\"Color\":\"red\",\"Price\":19.95,\"IsNew\":true}"));
+
+        return data;
+    }
+
+    private static TheoryData<JsonPathTestCase> CreateStructInputAllowMissingData()
+    {
+        var store = CreateStore();
+
+        var data = new TheoryData<JsonPathTestCase>();
+        data.Add(new JsonPathTestCase("missing", "{.hello}", store, string.Empty));
+        data.Add(new JsonPathTestCase("missing with text", "before-{.hello}after", store, "before-after"));
+        return data;
+    }
+
+    private static TheoryData<JsonPathTestCase> CreateStructInputFailureData()
+    {
+        var store = CreateStore();
+
+        var data = new TheoryData<JsonPathTestCase>();
+        data.Add(new JsonPathTestCase("invalid identifier", "{hello}", store, "unrecognized identifier", true));
+        data.Add(new JsonPathTestCase("missing field", "{.hello}", store, "is not found", true));
+        data.Add(new JsonPathTestCase("invalid array", "{.Labels[0]}", store, "is not array or slice", true));
+        data.Add(new JsonPathTestCase("invalid filter operator", "{.Book[?(@.Price<>10)]}", store, "unrecognized filter operator", true));
+        data.Add(new JsonPathTestCase("redundant end", "{range .Labels.*}{@}{end}{end}", store, "not in range", true));
+        return data;
+    }
+
+    private static TheoryData<JsonPathTestCase> CreateJsonInputData()
+    {
+        var json = """
+        [
+            {"id": "i1", "x":4, "y":-5},
+            {"id": "i2", "x":-2, "y":-5, "z":1},
+            {"id": "i3", "x":8, "y":3},
+            {"id": "i4", "x":-6, "y":-1},
+            {"id": "i5", "x":0, "y":2, "z":1},
+            {"id": "i6", "x":1, "y":4},
+            {"id": "i7", "x":null, "y":4}
+        ]
+        """;
+
+        var document = JsonDocument.Parse(json);
+        var root = document.RootElement.Clone();
+
+        var data = new TheoryData<JsonPathTestCase>();
+        data.Add(new JsonPathTestCase("exists filter", "{[?(@.z)].id}", root, "i2 i5"));
+        data.Add(new JsonPathTestCase("bracket key", "{[0]['id']}", root, "i1"));
+        data.Add(new JsonPathTestCase("nil value", "{[-1]['x']}", root, "null"));
+        return data;
+    }
+
+    private static TheoryData<JsonPathTestCase> CreateKubernetesSampleData()
+    {
+        var json = File.ReadAllText("TestData/kubernetes.json");
+        var document = JsonDocument.Parse(json);
+        var root = document.RootElement.Clone();
+
+        var data = new TheoryData<JsonPathTestCase>();
+        data.Add(new JsonPathTestCase("range item", "{range .items[*]}{.metadata.name}, {end}{.kind}", root, "127.0.0.1, 127.0.0.2, List"));
+        data.Add(new JsonPathTestCase("range item with quote", "{range .items[*]}{.metadata.name}{\"\t\"}{end}", root, "127.0.0.1\t127.0.0.2\t"));
+        data.Add(new JsonPathTestCase("range addresses", "{.items[*].status.addresses[*].address}", root, "127.0.0.1 127.0.0.2 127.0.0.3"));
+        data.Add(new JsonPathTestCase("double range", "{range .items[*]}{range .status.addresses[*]}{.address}, {end}{end}", root,
+            "127.0.0.1, 127.0.0.2, 127.0.0.3, "));
+        data.Add(new JsonPathTestCase("item name", "{.items[*].metadata.name}", root, "127.0.0.1 127.0.0.2"));
+        data.Add(new JsonPathTestCase("union capacity", "{.items[*]['metadata.name', 'status.capacity']}", root,
+            "127.0.0.1 127.0.0.2 {\"cpu\":\"4\"} {\"cpu\":\"8\"}"));
+        data.Add(new JsonPathTestCase("range capacity", "{range .items[*]}[{.metadata.name}, {.status.capacity}] {end}", root,
+            "[127.0.0.1, {\"cpu\":\"4\"}] [127.0.0.2, {\"cpu\":\"8\"}] "));
+        data.Add(new JsonPathTestCase("user password", "{.users[?(@.name==\"e2e\")].user.password}", root, "secret"));
+        data.Add(new JsonPathTestCase("hostname", "{.items[0].metadata.labels.kubernetes\\.io/hostname}", root, "127.0.0.1"));
+        data.Add(new JsonPathTestCase("hostname filter", "{.items[?(@.metadata.labels.kubernetes\\.io/hostname==\"127.0.0.1\")].kind}", root, "None"));
+        data.Add(new JsonPathTestCase("bool item", "{.items[?(@..ready==true)].metadata.name}", root, "127.0.0.1"));
+
+        return data;
+    }
+
+    private static TheoryData<JsonPathTestCase> CreateKubernetesSampleSortedData()
+    {
+        var json = File.ReadAllText("TestData/kubernetes.json");
+        var document = JsonDocument.Parse(json);
+        var root = document.RootElement.Clone();
+
+        var data = new TheoryData<JsonPathTestCase>();
+        data.Add(new JsonPathTestCase("recursive name", "{..name}", root, "127.0.0.1 127.0.0.2 myself e2e"));
+        return data;
+    }
+
+    private static TheoryData<JsonPathTestCase> CreateEmptyRangeData()
+    {
+        var document = JsonDocument.Parse("{\"items\":[]}");
+        var root = document.RootElement.Clone();
+
+        var data = new TheoryData<JsonPathTestCase>();
+        data.Add(new JsonPathTestCase("empty range", "{range .items[*]}{.metadata.name}{end}", root, string.Empty));
+        return data;
+    }
+
+    private static Store CreateStore() => new()
+    {
+        Name = "jsonpath",
+        Book = new List<Book>
+        {
+            new("reference", "Nigel Rees", "Sayings of the Centurey", 8.95f),
+            new("fiction", "Evelyn Waugh", "Sword of Honour", 12.99f),
+            new("fiction", "Herman Melville", "Moby Dick", 8.99f),
+        },
+        Bicycle = new List<Bicycle>
+        {
+            new("red", 19.95f, true),
+            new("green", 20.01f, false),
+        },
+        Labels = new Dictionary<string, int>
+        {
+            ["engieer"] = 10,
+            ["web/html"] = 15,
+            ["k8s-app"] = 20,
+        },
+        Employees = new Dictionary<string, string>
+        {
+            ["jason"] = "manager",
+            ["dan"] = "clerk",
+        },
+    };
+
+    private record TestStruct([property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("value")] object Value,
+        [property: JsonPropertyName("type")] string Type);
+
+    private record Book(
+        [property: JsonPropertyName("Category")] string Category,
+        [property: JsonPropertyName("Author")] string Author,
+        [property: JsonPropertyName("Title")] string Title,
+        [property: JsonPropertyName("Price")] float Price);
+
+    private record Bicycle(
+        [property: JsonPropertyName("Color")] string Color,
+        [property: JsonPropertyName("Price")] float Price,
+        [property: JsonPropertyName("IsNew")] bool IsNew);
+
+    private sealed class Store
+    {
+        [JsonPropertyName("Book")] public List<Book> Book { get; init; } = new();
+        [JsonPropertyName("Bicycle")] public List<Bicycle> Bicycle { get; init; } = new();
+        [JsonPropertyName("Name")] public string Name { get; init; } = string.Empty;
+        [JsonPropertyName("Labels")] public Dictionary<string, int> Labels { get; init; } = new();
+        [JsonPropertyName("Employees")] public Dictionary<string, string> Employees { get; init; } = new();
+    }
+}

--- a/tests/ClientGo.JsonPath.Tests/TestData/kubernetes.json
+++ b/tests/ClientGo.JsonPath.Tests/TestData/kubernetes.json
@@ -1,0 +1,64 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "kind": "None",
+      "metadata": {
+        "name": "127.0.0.1",
+        "labels": {
+          "kubernetes.io/hostname": "127.0.0.1"
+        }
+      },
+      "status": {
+        "capacity": {
+          "cpu": "4"
+        },
+        "ready": true,
+        "addresses": [
+          {
+            "type": "LegacyHostIP",
+            "address": "127.0.0.1"
+          }
+        ]
+      }
+    },
+    {
+      "kind": "None",
+      "metadata": {
+        "name": "127.0.0.2",
+        "labels": {
+          "kubernetes.io/hostname": "127.0.0.2"
+        }
+      },
+      "status": {
+        "capacity": {
+          "cpu": "8"
+        },
+        "ready": false,
+        "addresses": [
+          {
+            "type": "LegacyHostIP",
+            "address": "127.0.0.2"
+          },
+          {
+            "type": "another",
+            "address": "127.0.0.3"
+          }
+        ]
+      }
+    }
+  ],
+  "users": [
+    {
+      "name": "myself",
+      "user": {}
+    },
+    {
+      "name": "e2e",
+      "user": {
+        "username": "admin",
+        "password": "secret"
+      }
+    }
+  ]
+}

--- a/tests/ClientGo.JsonPath.Tests/Usings.cs
+++ b/tests/ClientGo.JsonPath.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
## Summary
- stop using Record.Exception in the JSONPath test helpers and rely on direct execution or Assert.ThrowsAny instead
- ensure failure cases continue asserting the expected error messages with modern xUnit APIs

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691543fc2e548326a4c865ac8f6c8237)