### PR TITLE
Port Kubernetes JSONPath printer

### DIFF
--- a/src/ClientGo.JsonPath/JsonPathPrinter.cs
+++ b/src/ClientGo.JsonPath/JsonPathPrinter.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ClientGo.JsonPath;
+
+public interface IUnstructured
+{
+    IDictionary<string, object?> UnstructuredContent();
+}
+
+public sealed class JsonPathPrinter
+{
+    private readonly string _rawTemplate;
+    private readonly JsonPath _jsonPath;
+    private static readonly JsonSerializerOptions DebugSerializerOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    private JsonPathPrinter(string template, JsonPath jsonPath)
+    {
+        _rawTemplate = template;
+        _jsonPath = jsonPath;
+    }
+
+    public static JsonPathPrinter Create(string template)
+    {
+        if (template is null)
+        {
+            throw new ArgumentNullException(nameof(template));
+        }
+
+        var jsonPath = new JsonPath("out");
+        jsonPath.Parse(template);
+        return new JsonPathPrinter(template, jsonPath);
+    }
+
+    public JsonPathPrinter AllowMissingKeys(bool allow)
+    {
+        _jsonPath.AllowMissingKeys(allow);
+        return this;
+    }
+
+    public void EnableJsonOutput(bool enable) => _jsonPath.EnableJsonOutput(enable);
+
+    public void PrintObj(object? obj, TextWriter writer)
+    {
+        if (writer is null)
+        {
+            throw new ArgumentNullException(nameof(writer));
+        }
+
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        var type = obj.GetType();
+        var packagePath = type.Namespace ?? string.Empty;
+        if (ObjectSourceChecker.InternalObjectPreventer.IsForbidden(packagePath))
+        {
+            throw new InvalidOperationException(ObjectSourceChecker.InternalObjectPrinterErr);
+        }
+
+        object? queryObj = obj;
+        if (obj is IUnstructured unstructured)
+        {
+            queryObj = unstructured.UnstructuredContent();
+        }
+        else
+        {
+            var json = JsonSerializer.Serialize(obj);
+            queryObj = JsonSerializer.Deserialize<JsonElement>(json);
+        }
+
+        try
+        {
+            _jsonPath.Execute(writer, queryObj);
+        }
+        catch (Exception ex)
+        {
+            var message = BuildDebugMessage(ex, queryObj);
+            throw new InvalidOperationException($"error executing jsonpath \"{_rawTemplate}\": {message}\n", ex);
+        }
+    }
+
+    private string BuildDebugMessage(Exception exception, object? queryObj)
+    {
+        var builder = new StringBuilder();
+        builder.AppendFormat("Error executing template: {0}. Printing more information for debugging the template:\n", exception.Message);
+        builder.AppendLine("\ttemplate was:");
+        builder.Append('\t').Append('\t').AppendLine(_rawTemplate);
+        builder.AppendLine("\tobject given to jsonpath engine was:");
+        builder.Append('\t').Append('\t').AppendLine(SerializeForDebug(queryObj));
+        builder.AppendLine();
+        return builder.ToString();
+    }
+
+    private static string SerializeForDebug(object? value)
+    {
+        try
+        {
+            if (value is JsonElement element)
+            {
+                return JsonSerializer.Serialize(element, DebugSerializerOptions);
+            }
+
+            return JsonSerializer.Serialize(value, DebugSerializerOptions);
+        }
+        catch
+        {
+            return value?.ToString() ?? "null";
+        }
+    }
+}
+
+public static class ObjectSourceChecker
+{
+    public const string InternalObjectPrinterErr = "a versioned object must be passed to a printer";
+
+    public static IllegalPackageSourceChecker InternalObjectPreventer { get; } = new(new[]
+    {
+        "k8s.io/kubernetes/pkg/apis/",
+    });
+
+    public static bool IsInternalObjectError(Exception? error) =>
+        error is not null && error.Message == InternalObjectPrinterErr;
+}
+
+public sealed class IllegalPackageSourceChecker
+{
+    private readonly string[] _disallowedPrefixes;
+
+    public IllegalPackageSourceChecker(IEnumerable<string> disallowedPrefixes)
+    {
+        if (disallowedPrefixes is null)
+        {
+            throw new ArgumentNullException(nameof(disallowedPrefixes));
+        }
+
+        _disallowedPrefixes = disallowedPrefixes.ToArray();
+    }
+
+    public bool IsForbidden(string? packagePath)
+    {
+        if (string.IsNullOrEmpty(packagePath))
+        {
+            return false;
+        }
+
+        foreach (var prefix in _disallowedPrefixes)
+        {
+            if (packagePath.StartsWith(prefix, StringComparison.Ordinal) ||
+                packagePath.Contains($"/vendor/{prefix}", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/ClientGo.JsonPath.Tests/JsonPathPrinterTests.cs
+++ b/tests/ClientGo.JsonPath.Tests/JsonPathPrinterTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json.Serialization;
+using ClientGo.JsonPath;
+using Xunit;
+
+namespace ClientGo.JsonPath.Tests;
+
+public sealed class JsonPathPrinterTests
+{
+    private const string Template = "{.metadata.name}";
+
+    public static IEnumerable<object[]> PrintTestCases()
+    {
+        yield return new object[]
+        {
+            "pod",
+            (Func<object>)(() => new Pod
+            {
+                Metadata = new ObjectMeta { Name = "pod" }
+            }),
+            false,
+        };
+
+        yield return new object[] { "emptyPodList", (Func<object>)(() => new PodList()), true };
+
+        yield return new object[]
+        {
+            "nonEmptyPodList",
+            (Func<object>)(() =>
+            {
+                var list = new PodList();
+                list.Items.Add(new Pod());
+                return list;
+            }),
+            true,
+        };
+
+        yield return new object[]
+        {
+            "endpoints",
+            (Func<object>)(() => new Endpoints
+            {
+                Subsets =
+                {
+                    new EndpointSubset
+                    {
+                        Addresses =
+                        {
+                            new EndpointAddress { Ip = "127.0.0.1" },
+                            new EndpointAddress { Ip = "localhost" },
+                        },
+                        Ports = { new EndpointPort { Port = 8080 } },
+                    }
+                }
+            }),
+            true,
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(PrintTestCases))]
+    public void PrintObjMatchesGoBehavior(string name, Func<object> objectFactory, bool expectError)
+    {
+        var printer = JsonPathPrinter.Create(Template);
+        var writer = new StringWriter();
+        var exception = Record.Exception(() => printer.PrintObj(objectFactory(), writer));
+        if (expectError)
+        {
+            Assert.True(exception is not null, $"Expected an exception for {name}.");
+        }
+        else
+        {
+            Assert.True(exception is null, $"Unexpected exception for {name}: {exception}");
+            Assert.Equal("pod", writer.ToString());
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(PrintTestCases))]
+    public void PrintObjMatchesGoBehaviorWithJsonOutput(string name, Func<object> objectFactory, bool expectError)
+    {
+        var printer = JsonPathPrinter.Create(Template);
+        printer.EnableJsonOutput(true);
+        var writer = new StringWriter();
+        var exception = Record.Exception(() => printer.PrintObj(objectFactory(), writer));
+        if (expectError)
+        {
+            Assert.True(exception is not null, $"Expected an exception for {name}.");
+        }
+        else
+        {
+            Assert.True(exception is null, $"Unexpected exception for {name}: {exception}");
+            Assert.Equal("[\n  \"pod\"\n]\n", writer.ToString());
+        }
+    }
+
+    private sealed class ObjectMeta
+    {
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+    }
+
+    private sealed class Pod
+    {
+        [JsonPropertyName("metadata")]
+        public ObjectMeta? Metadata { get; set; }
+    }
+
+    private sealed class PodList
+    {
+        [JsonPropertyName("items")]
+        public List<Pod> Items { get; } = new();
+    }
+
+    private sealed class EndpointAddress
+    {
+        [JsonPropertyName("ip")]
+        public string? Ip { get; set; }
+    }
+
+    private sealed class EndpointPort
+    {
+        [JsonPropertyName("port")]
+        public int Port { get; set; }
+    }
+
+    private sealed class EndpointSubset
+    {
+        [JsonPropertyName("addresses")]
+        public List<EndpointAddress> Addresses { get; init; } = new();
+
+        [JsonPropertyName("ports")]
+        public List<EndpointPort> Ports { get; init; } = new();
+    }
+
+    private sealed class Endpoints
+    {
+        [JsonPropertyName("subsets")]
+        public List<EndpointSubset> Subsets { get; init; } = new();
+    }
+}


### PR DESCRIPTION
## Summary
- port the Kubernetes CLI runtime JSONPath printer to the ClientGo.JsonPath library, including internal object prevention checks
- expose an IUnstructured hook and debugging output when template execution fails
- add parity unit tests covering PrintObj behavior with and without JSON output

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69155e14eb608326822d7b4305454977)